### PR TITLE
Small change in definition of block elements

### DIFF
--- a/assets/styles/base/_normalise.scss
+++ b/assets/styles/base/_normalise.scss
@@ -38,7 +38,7 @@ body {
 	box-sizing: inherit;
 }
 
-article, aside, details, figure, figcaption, header, footer, hgroup, menu, nav, section, summary, hr { display: block; }
+article, aside, details, figure, figcaption, header, footer, hgroup, main, menu, nav, section, summary, hr { display: block; }
 
 audio,
 canvas,


### PR DESCRIPTION
Set <main> default display type as block. This element is inline in IE.